### PR TITLE
fix: add locale fallback for translation variants

### DIFF
--- a/dist/microbitMore.mjs
+++ b/dist/microbitMore.mjs
@@ -5039,8 +5039,20 @@ var formatMessage = function formatMessage(messageData) {
  */
 var setupTranslations = function setupTranslations() {
   var localeSetup = formatMessage.setup();
-  if (localeSetup && localeSetup.translations[localeSetup.locale]) {
-    Object.assign(localeSetup.translations[localeSetup.locale], translations[localeSetup.locale]);
+  if (!localeSetup) return;
+
+  var currentLocale = localeSetup.locale;
+  if (!currentLocale) return;
+
+  // Try exact match first, then fall back to base locale (e.g., 'de-DE' -> 'de')
+  var baseLocale = currentLocale.split('-')[0].split('_')[0];
+  var translationKey = translations[currentLocale] ? currentLocale : null;
+  if (!translationKey && baseLocale !== currentLocale) {
+    translationKey = translations[baseLocale] ? baseLocale : null;
+  }
+
+  if (localeSetup.translations[currentLocale] && translationKey) {
+    Object.assign(localeSetup.translations[currentLocale], translations[translationKey]);
   }
 };
 var EXTENSION_ID = 'microbitMore';

--- a/src/vm/extensions/block/index.js
+++ b/src/vm/extensions/block/index.js
@@ -14,10 +14,22 @@ let formatMessage = messageData => messageData.defaultMessage;
  */
 const setupTranslations = () => {
     const localeSetup = formatMessage.setup();
-    if (localeSetup && localeSetup.translations[localeSetup.locale]) {
+    if (!localeSetup) return;
+
+    const currentLocale = localeSetup.locale;
+    if (!currentLocale) return;
+
+    // Try exact match first, then fall back to base locale (e.g., 'de-DE' -> 'de')
+    const baseLocale = currentLocale.split('-')[0].split('_')[0];
+    let translationKey = translations[currentLocale] ? currentLocale : null;
+    if (!translationKey && baseLocale !== currentLocale) {
+        translationKey = translations[baseLocale] ? baseLocale : null;
+    }
+
+    if (localeSetup.translations[currentLocale] && translationKey) {
         Object.assign(
-            localeSetup.translations[localeSetup.locale],
-            translations[localeSetup.locale]
+            localeSetup.translations[currentLocale],
+            translations[translationKey]
         );
     }
 };


### PR DESCRIPTION
Add locale fallback logic to support regional locale variants (e.g., de-DE, de_DE) that fall back to base locale (de) when exact match is not found.

This fixes an issue where German translations were not loading in Scratch environments that use locale codes like 'de-DE' instead of just 'de'. The setupTranslations() function now:

1. Checks for exact locale match first (e.g., 'de-DE')
2. Falls back to base locale if no exact match (e.g., 'de-DE' -> 'de')
3. Handles both hyphen and underscore separators ('de-DE' and 'de_DE')

Tested with:
- German (de-DE, de_DE) -> successfully loads 'de' translations
- Japanese and other existing locales continue to work
- English fallback remains unchanged